### PR TITLE
try to remove Fast dependency on runtime requirement

### DIFF
--- a/lib/sequel-fixture.rb
+++ b/lib/sequel-fixture.rb
@@ -1,7 +1,8 @@
 require "sequel"
 require "symbolmatrix"
-require "fast"
+#require "fast/fast"
 
+require 'pry'
 require "sequel-fixture/version"
 require "sequel-fixture/exceptions"
 require "sequel-fixture/util"
@@ -47,7 +48,10 @@ class Sequel::Fixture
   def load(fixture)
     raise LoadingFixtureIllegal, "A check has already been made, loading a different fixture is illegal" if @checked
     
-    Fast.dir("#{fixtures_path}/#{fixture}").files.to.symbols.each do |file|
+    Dir["#{fixtures_path}/#{fixture}/*.yaml"].each do |f|
+    
+      file = File.basename(f,".yaml").to_sym
+      
       @data ||= {}
       @schema ||= {}
 

--- a/lib/sequel-fixture.rb
+++ b/lib/sequel-fixture.rb
@@ -1,8 +1,5 @@
 require "sequel"
 require "symbolmatrix"
-#require "fast/fast"
-
-require 'pry'
 require "sequel-fixture/version"
 require "sequel-fixture/exceptions"
 require "sequel-fixture/util"

--- a/sequel-fixture.gemspec
+++ b/sequel-fixture.gemspec
@@ -10,9 +10,11 @@ Gem::Specification.new do |gem|
 
   gem.add_dependency "sequel"         # Stating the obvious
   gem.add_dependency "symbolmatrix"   # Because its easy to use
-  gem.add_dependency "fast"           # Fast was needed. This is a testing gem, there's no problem with extra load
 
   gem.add_development_dependency "rspec"
+  
+  # Fast was needed,as a testing gem, there's no problem with extra load here
+  gem.add_development_dependency "fast"  
 
   gem.files         = `git ls-files`.split($\)
   gem.executables   = gem.files.grep(%r{^bin/}).map{ |f| File.basename(f) }


### PR DESCRIPTION
I had a problem on a deployment machine, where sub-setter refuse to load properly.

This try to place Fast gem requirement, only for test and not for general runtime
Don't know if that is equivalent, as I don't use your normalize call

Tests pass, and my deployment problem, sound over with this.
