### PR TITLE
Remove call to `#to_h` as it produces an error 1.9.3p429

### DIFF
--- a/lib/sequel-fixture.rb
+++ b/lib/sequel-fixture.rb
@@ -120,10 +120,10 @@ class Sequel::Fixture
     @data.each do |table_name, table_data|
       table_data.rows.each do |values|
         begin
-          @connection[table_name].insert(simplify(values.to_h))
+          @connection[table_name].insert(simplify(values))
         rescue MissingProcessedValueError => m
           rollback
-          raise MissingProcessedValueError, "In record '#{values.to_h}' to be inserted into '#{table_name}', the processed value of field '#{m.field}' is missing, aborting."
+          raise MissingProcessedValueError, "In record '#{values}' to be inserted into '#{table_name}', the processed value of field '#{m.field}' is missing, aborting."
         rescue NoMethodError => e
           raise IllegalFixtureFormat, "In record '#{values}', data must be formatted as arrays of hashes. Check 'data' section in '#{table_name}.yaml'"
         end

--- a/lib/sequel-fixture.rb
+++ b/lib/sequel-fixture.rb
@@ -60,7 +60,6 @@ class Sequel::Fixture
       @schema ||= {}
 
       file_data = SymbolMatrix.new file
-      # require 'pry'; binding.pry
 
       if file_data
         @data[tablename] = Table.new(file_data[:data]) if file_data.key?(:data)

--- a/lib/sequel-fixture.rb
+++ b/lib/sequel-fixture.rb
@@ -10,7 +10,7 @@ require "sequel-fixture/table"
 module Sequel; end
 
 class Sequel::Fixture
-  
+
   # === Description
   # Returns the current path to the fixtures folder
   #
@@ -18,49 +18,58 @@ class Sequel::Fixture
     @@path ||= "test/fixtures"
   end
 
-  
+
   # === Description
   # Set the current path of the fixtures folder
   #
   def self.path=(path)
     @@path = path
   end
-  
+
   # === Description
   # Initializes the fixture handler
-  # Accepts optionally a symbol as a reference to the fixture
+  # Accepts optionally a symbol as a reference to the fixture, or a path to an individual fixture
   # and a Sequel::Database connection
   def initialize(fixture = nil, connection = nil, option_push = true)
     @schema = {}
     @data = {}
-    
+
     load(fixture) if fixture
-    
+
     @connection = connection if connection
     push if fixture && connection && option_push
   end
 
-  
+
   # === Description
-  # Loads the fixture files into this instance
+  # Loads the fixture files or individual fixture into this instance
   #
   def load(fixture)
     raise LoadingFixtureIllegal, "A check has already been made, loading a different fixture is illegal" if @checked
-    
-    Fast.dir("#{fixtures_path}/#{fixture}").files.to.symbols.each do |file|
+    fixture_files = if fixture.is_a? Array
+      fixture.map { |f| "#{fixtures_path}/#{f}" }
+    elsif Fast.dir? "#{fixtures_path}/#{fixture}"
+      Fast.dir("#{fixtures_path}/#{fixture}").files.to.symbols.map { |f| "#{fixtures_path}/#{fixture}/#{f}.yaml" }
+    else
+      ["#{fixtures_path}/#{fixture}"]
+    end
+
+    fixture_files.each do |file|
+      tablename = file[/([^\/]+).ya?ml$/, 1].to_sym
       @data ||= {}
       @schema ||= {}
 
-      file_data = SymbolMatrix.new "#{fixtures_path}/#{fixture}/#{file}.yaml"
+      file_data = SymbolMatrix.new file
+      # require 'pry'; binding.pry
 
       if file_data
-        @data[file] = Table.new(file_data[:data]) if file_data.key?(:data)
-        @schema[file] = file_data[:schema] if file_data.key?(:schema)
+        @data[tablename] = Table.new(file_data[:data]) if file_data.key?(:data)
+        @schema[tablename] = file_data[:schema] if file_data.key?(:schema)
       end
     end
   end
 
-  
+
   # === Description
   # Returns the current fixtures path where Sequel::Fixture looks for fixture folders
   #
@@ -75,16 +84,16 @@ class Sequel::Fixture
   def method_missing(key, *args)
     return @data[key] if @data && @data.has_key?(key)
     return super
-  end    
-  
+  end
+
   # === Description
   # Returns the SymbolMatrix with the data referring to that table
   #
   def [](reference)
     @data[reference]
   end
-  
-  
+
+
   # === Description
   # Forces the check to pass. Dangerous!
   #
@@ -92,7 +101,7 @@ class Sequel::Fixture
     @checked = true
   end
 
-  
+
   # === Description
   # Assures that the tables are empty before proceeding
   #
@@ -101,11 +110,11 @@ class Sequel::Fixture
 
     raise MissingFixtureError, "No fixture has been loaded, nothing to check" unless @data.length > 0
     raise MissingConnectionError, "No connection has been provided, impossible to check" unless @connection
-    
+
     return @checked = true
   end
 
-  
+
   # === Description
   # Initializes fixture schema and Inserts the fixture data into the corresponding
   # tables
@@ -116,7 +125,7 @@ class Sequel::Fixture
     @schema.each do |table, matrix|
       push_schema(table, matrix)
     end
-    
+
     @data.each do |table_name, table_data|
       table_data.rows.each do |values|
         begin
@@ -131,10 +140,10 @@ class Sequel::Fixture
     end
   end
 
-  
-  # === Description 
+
+  # === Description
   # Create the schema in our DB connection based on the schema values
-  #  
+  #
   def push_schema(table, values)
     ## Lets passively ignore the schema if the table already exists
     return if @connection.table_exists?(table.to_sym)
@@ -144,7 +153,7 @@ class Sequel::Fixture
     values.each do |column_def|
       pkey_data = column_def if column_def["primary_key"]
     end
-    
+
     ## Create the table with the primary key
     @connection.create_table(table) do
       column(pkey_data["name"].to_sym, pkey_data["type"].to_sym)
@@ -157,15 +166,15 @@ class Sequel::Fixture
       end
     end
   end
-  
-  
+
+
   # === Description
   # Empties the tables, only if they were empty to begin with
   #
   def rollback
     begin
       check
-      
+
       @data.each_key do |table|
         @connection[table].truncate
       end
@@ -174,7 +183,7 @@ class Sequel::Fixture
     end
   end
 
-  
+
   # === Description
   # Sets the connection. Raises an ChangingConnectionIllegal exception if this fixture has
   # already been checked
@@ -188,5 +197,5 @@ class Sequel::Fixture
 
   attr_reader :connection
   attr_reader :data
-  attr_reader :schema  
+  attr_reader :schema
 end

--- a/lib/sequel-fixture/version.rb
+++ b/lib/sequel-fixture/version.rb
@@ -1,5 +1,5 @@
 module Sequel
   class Fixture
-    VERSION = "2.0.1"
+    VERSION = "2.0.2"
   end
 end


### PR DESCRIPTION
I am running Sequel::Fixture with Ruby 1.9.3p429. When the call to `#table_data.rows` gets executed, it returns a simple list of hashes. In 1.9.3 instances of Hash do not respond to `#to_h` (see [Ruby doc](http://www.ruby-doc.org/core-1.9.3/Hash.html)). Is there any specific reason for that method call? If there is, perhaps I can amend the PR so that it will fallback to `#to_hash` where `#t_h` is not available.
