### PR TITLE
Allow file extensions other than .yaml

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -4,6 +4,8 @@ source 'https://rubygems.org'
 gemspec
 
 group :test do
+  gem "rspec", ">=3.2"
+  gem "byebug"
   gem "sqlite3"
   gem "rake"
 end

--- a/spec/sequel/fixture_spec.rb
+++ b/spec/sequel/fixture_spec.rb
@@ -50,22 +50,46 @@ describe Sequel::Fixture do
 
   describe "#load" do
     context "there is a valid fixture folder setup" do
-      before do
-        Sequel::Fixture.path = "test/fixtures"
-        Fast.file! "test/fixtures/test/users.yaml"
-        Fast.file! "test/fixtures/test/actions.yaml"
+      shared_examples_for "valid fixture folder setup" do
+
+        around do |example|
+          Sequel::Fixture.path = "test/fixtures"
+          Fast.file! file1
+          Fast.file! file2
+
+          example.run
+
+          Fast.dir.remove! :test
+        end
+
+        it "loads the fixture YAML files using SymbolMatrix (third-party)" do
+          fix = Sequel::Fixture.new
+          allow(fix).to receive :check
+          expect(SymbolMatrix).to receive(:new).with file1
+          expect(SymbolMatrix).to receive(:new).with file2
+          fix.load :test
+        end
       end
 
-      it "loads the fixture YAML files using SymbolMatrix (third-party)" do
-        fix = Sequel::Fixture.new
-        allow(fix).to receive :check
-        expect(SymbolMatrix).to receive(:new).with "test/fixtures/test/users.yaml"
-        expect(SymbolMatrix).to receive(:new).with "test/fixtures/test/actions.yaml"
-        fix.load :test
+      context "with files having a .yaml extension" do
+        let(:file1) { "test/fixtures/test/users.yaml" }
+        let(:file2) { "test/fixtures/test/actions.yaml" }
+
+        it_behaves_like "valid fixture folder setup"
       end
 
-      after do
-        Fast.dir.remove! :test
+      context "with files having a .yml extension" do
+        let(:file1) { "test/fixtures/test/users.yml" }
+        let(:file2) { "test/fixtures/test/actions.yml" }
+
+        it_behaves_like "valid fixture folder setup"
+      end
+
+      context "with files having a .erb extension" do
+        let(:file1) { "test/fixtures/test/users.yml.erb" }
+        let(:file2) { "test/fixtures/test/actions.yml.erb" }
+
+        it_behaves_like "valid fixture folder setup"
       end
     end
 

--- a/spec/sequel/util_spec.rb
+++ b/spec/sequel/util_spec.rb
@@ -5,7 +5,7 @@ describe Sequel::Fixture do
   # This should go in a dependency, pending refactoring TODO
   describe "#simplify" do
     context "when receiving a multidimensional hash containing a field with raw and processed" do
-      it "should convert it in a simple hash using the processed value as replacement" do
+      it "converts it in a simple hash using the processed value as replacement" do
         base_hash = {
           :name => "Jane",
           :band => "Witherspoons",
@@ -18,20 +18,20 @@ describe Sequel::Fixture do
             :processed => "jane@gmail.com"
           }
         }
-        
+
         fix = Sequel::Fixture.new
         simplified = fix.simplify(base_hash)
-        simplified.should == {
+        expect(simplified).to eq({
           :name => "Jane",
           :band => "Witherspoons",
           :pass => "53oih7fhjdgj3f8=",
           :email => "jane@gmail.com"
-        }
+        })
       end
     end
-    
+
     context "the multidimensional array is missing the processed part of the field" do
-      it "should raise an exception" do
+      it "raises an exception" do
         base_hash = {
           :name => "Jane",
           :pass => {
@@ -43,10 +43,10 @@ describe Sequel::Fixture do
             :processed => "jane@gmail.com"
           }
         }
-        
+
         fix = Sequel::Fixture.new
         expect { fix.simplify(base_hash)
-        }.to raise_error Sequel::Fixture::MissingProcessedValueError, 
+        }.to raise_error Sequel::Fixture::MissingProcessedValueError,
           "The processed value to insert into the db is missing from the field 'pass', aborting"
       end
     end


### PR DESCRIPTION
Allows fixture files with different extensions

There are two primary use-cases:
1. Allow sharing of fixtures with a Rails project, where generated fixtures usually have the .yml extension instead of .yaml
2. Allow ERB fixture files with .yml.erb extension. This part depends on a PR to the `SymbolMatrix` gem to parse ERB when loading (https://github.com/Fetcher/symbolmatrix/pull/7).

In addition, I've updated specs for rspec 3, fixing failures (global `stub`) and deprecation warnings for the old `should` syntax and message receiving. (https://relishapp.com/rspec/rspec-mocks/v/3-2/docs/old-syntax)
